### PR TITLE
refactor: remove axis_if and flatten keccak_core interfaces

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "lib/common_rtl"]
-	path = lib/common_rtl
-	url = ../common-rtl.git
 [submodule "build-tools"]
 	path = build-tools
 	url = ../build-tools.git

--- a/rtl.f
+++ b/rtl.f
@@ -1,8 +1,6 @@
 # --- Packages (Must be compiled first) ---
 rtl/keccak_pkg.sv
 
-# --- Common RTL (Interfaces & Helpers) ---
-lib/common_rtl/rtl/axis_if.sv
 
 # --- Keccak Step Modules ---
 rtl/chi_step.sv

--- a/rtl/keccak_core.sv
+++ b/rtl/keccak_core.sv
@@ -39,8 +39,6 @@ module keccak_core (
     input   wire  [XOF_LEN_WIDTH-1:0]       xof_len_i,     // 0 = Infinite/Continuous Mode, else specific byte length
     input   wire                            stop_i,
 
-`ifdef SYNTHESIS
-    // Expanded ports for synthesis top-level (to avoid "unconnected interface port" errors in Slang/Yosys)
     input  wire  [DWIDTH-1:0]               s_axis_tdata,
     input  wire                             s_axis_tvalid,
     input  wire                             s_axis_tlast,
@@ -52,13 +50,6 @@ module keccak_core (
     output wire                             m_axis_tlast,
     output wire  [KEEP_WIDTH-1:0]           m_axis_tkeep,
     input  wire                             m_axis_tready
-`else
-    // AXI4-Stream Interface - Sink (Input)
-    axis_if.sink                            s_axis,
-
-    // AXI4-Stream Interface - Source (Output)
-    axis_if.source                          m_axis
-`endif
 );
     // Dataflow Summary:
     // AXI Sink -> Absorb (KAU) -> State Array
@@ -84,34 +75,18 @@ module keccak_core (
     logic                   t_ready_i;
 
     // Assignments: Sink (Input from Interface -> Internal)
-`ifdef SYNTHESIS
     assign t_data_i       = s_axis_tdata;
     assign t_valid_i      = s_axis_tvalid;
     assign t_last_i       = s_axis_tlast;
     assign t_keep_i       = s_axis_tkeep;
     assign s_axis_tready  = t_ready_o;
-`else
-    assign t_data_i       = s_axis.tdata;
-    assign t_valid_i      = s_axis.tvalid;
-    assign t_last_i       = s_axis.tlast;
-    assign t_keep_i       = s_axis.tkeep;
-    assign s_axis.tready  = t_ready_o; // Output to Interface
-`endif
 
     // Assignments: Source (Internal -> Output to Interface)
-`ifdef SYNTHESIS
     assign m_axis_tdata   = t_data_o;
     assign m_axis_tvalid  = t_valid_o;
     assign m_axis_tlast   = t_last_o;
     assign m_axis_tkeep   = t_keep_o;
     assign t_ready_i      = m_axis_tready;
-`else
-    assign m_axis.tdata   = t_data_o;
-    assign m_axis.tvalid  = t_valid_o;
-    assign m_axis.tlast   = t_last_o;
-    assign m_axis.tkeep   = t_keep_o;
-    assign t_ready_i      = m_axis.tready; // Input from Interface
-`endif
 
 
     // ==========================================================

--- a/tb/keccak_core_heavy_tb.sv
+++ b/tb/keccak_core_heavy_tb.sv
@@ -47,10 +47,18 @@ module keccak_core_heavy_tb;
     // NOTE: We use DWIDTH from keccak_pkg.
 
     // Sink Interface (Input to Core)
-    axis_if #(.DWIDTH(DWIDTH)) s_axis();
+    logic [DWIDTH-1:0]      s_axis_tdata;
+    logic                   s_axis_tvalid;
+    logic                   s_axis_tlast;
+    logic [KEEP_WIDTH-1:0]  s_axis_tkeep;
+    logic                   s_axis_tready;
 
     // Source Interface (Output from Core)
-    axis_if #(.DWIDTH(DWIDTH)) m_axis();
+    logic [DWIDTH-1:0]      m_axis_tdata;
+    logic                   m_axis_tvalid;
+    logic                   m_axis_tlast;
+    logic [KEEP_WIDTH-1:0]  m_axis_tkeep;
+    logic                   m_axis_tready;
 
     // Test Vector Definition
     typedef struct {
@@ -76,10 +84,18 @@ module keccak_core_heavy_tb;
         .stop_i         (stop_i),
 
         // Connect Sink Interface using the 'sink' modport
-        .s_axis         (s_axis.sink),
+        .s_axis_tdata   (s_axis_tdata),
+        .s_axis_tvalid  (s_axis_tvalid),
+        .s_axis_tlast   (s_axis_tlast),
+        .s_axis_tkeep   (s_axis_tkeep),
+        .s_axis_tready  (s_axis_tready),
 
         // Connect Source Interface using the 'source' modport
-        .m_axis         (m_axis.source)
+        .m_axis_tdata   (m_axis_tdata),
+        .m_axis_tvalid  (m_axis_tvalid),
+        .m_axis_tlast   (m_axis_tlast),
+        .m_axis_tkeep   (m_axis_tkeep),
+        .m_axis_tready  (m_axis_tready)
     );
 
     // =====================================================================
@@ -97,13 +113,13 @@ module keccak_core_heavy_tb;
         xof_len_i = 0;
 
         // Reset Sink Interface Signals
-        s_axis.tvalid = 0;
-        s_axis.tlast  = 0;
-        s_axis.tkeep  = 0;
-        s_axis.tdata  = 0;
+        s_axis_tvalid = 0;
+        s_axis_tlast  = 0;
+        s_axis_tkeep  = 0;
+        s_axis_tdata  = 0;
 
         // Reset Source Interface Backpressure
-        m_axis.tready = 0;
+        m_axis_tready = 0;
 
         @(posedge clk);
         @(posedge clk);
@@ -208,14 +224,14 @@ module keccak_core_heavy_tb;
         // Handle empty message case (Len=0)
         if (total_bytes == 0) begin
             @(posedge clk);
-            while (!s_axis.tready) @(posedge clk);
-            s_axis.tvalid <= 1;
-            s_axis.tlast  <= 1;
-            s_axis.tkeep  <= '0;
-            s_axis.tdata  <= '0;
+            while (!s_axis_tready) @(posedge clk);
+            s_axis_tvalid <= 1;
+            s_axis_tlast  <= 1;
+            s_axis_tkeep  <= '0;
+            s_axis_tdata  <= '0;
             @(posedge clk);
-            s_axis.tvalid <= 0;
-            s_axis.tlast  <= 0;
+            s_axis_tvalid <= 0;
+            s_axis_tlast  <= 0;
             return;
         end
 
@@ -226,17 +242,17 @@ module keccak_core_heavy_tb;
             @(posedge clk);
 
             // Flow Control: Drive if valid is low (idle) or ready is high (accepted)
-            if (!s_axis.tvalid || s_axis.tready) begin
-                s_axis.tvalid <= 1;
-                s_axis.tdata  <= '0;
-                s_axis.tkeep  <= '0;
-                s_axis.tlast  <= 0;
+            if (!s_axis_tvalid || s_axis_tready) begin
+                s_axis_tvalid <= 1;
+                s_axis_tdata  <= '0;
+                s_axis_tkeep  <= '0;
+                s_axis_tlast  <= 0;
 
                 // Pack up to 32 bytes (BYTES_PER_BEAT) into tdata
                 for (k = 0; k < BYTES_PER_BEAT; k++) begin
                     if ((sent_bytes + k) < total_bytes) begin
-                        s_axis.tdata[k*8 +: 8] <= msg_bytes[sent_bytes + k];
-                        s_axis.tkeep[k]        <= 1'b1;
+                        s_axis_tdata[k*8 +: 8] <= msg_bytes[sent_bytes + k];
+                        s_axis_tkeep[k]        <= 1'b1;
                     end
                 end
 
@@ -244,7 +260,7 @@ module keccak_core_heavy_tb;
 
                 // Assert T_LAST if this is the final chunk
                 if (sent_bytes >= total_bytes) begin
-                    s_axis.tlast <= 1'b1;
+                    s_axis_tlast <= 1'b1;
                 end
 
             end
@@ -252,15 +268,15 @@ module keccak_core_heavy_tb;
 
         // Cleanup
         @(posedge clk);
-        while (!s_axis.tready) @(posedge clk); // Wait for final handshake if pending
-        s_axis.tvalid <= 0;
-        s_axis.tlast  <= 0;
-        s_axis.tkeep  <= 0;
+        while (!s_axis_tready) @(posedge clk); // Wait for final handshake if pending
+        s_axis_tvalid <= 0;
+        s_axis_tlast  <= 0;
+        s_axis_tkeep  <= 0;
 
         // Verify tready behavior post-transaction
         #(1);
-        if (s_axis.tready === 1'bx) begin
-             $error("[FAIL] s_axis.tready is X (unknown) after driving message!");
+        if (s_axis_tready === 1'bx) begin
+             $error("[FAIL] s_axis_tready is X (unknown) after driving message!");
         end
     endtask
 
@@ -317,12 +333,12 @@ module keccak_core_heavy_tb;
             default:  rate_bytes = 136;
         endcase
 
-        m_axis.tready = 1;
+        m_axis_tready = 1;
 
         forever begin
             @(posedge clk);
 
-            if (m_axis.tvalid && m_axis.tready) begin
+            if (m_axis_tvalid && m_axis_tready) begin
 
                 // --- 1. SIGNAL VERIFICATION ---
 
@@ -361,11 +377,11 @@ module keccak_core_heavy_tb;
                 end
 
                 // C. Verify Keep
-                if (m_axis.tkeep !== exp_keep) begin
+                if (m_axis_tkeep !== exp_keep) begin
                     $error("[%s] SIGNAL ERROR: tkeep mismatch at DUT byte offset %0d",
                            test_name, bytes_squeezed_from_dut_total);
                     $display("\tExpected Keep: %b", exp_keep);
-                    $display("\tGot Keep:      %b", m_axis.tkeep);
+                    $display("\tGot Keep:      %b", m_axis_tkeep);
                 end
 
                 // D. Verify Last
@@ -379,15 +395,15 @@ module keccak_core_heavy_tb;
                         expected_bytes_this_beat2 = bytes_remaining_in_rate_block;
 
                     if (bytes_rem <= expected_bytes_this_beat2) exp_last = 1; else exp_last = 0;
-                    if (m_axis.tlast !== exp_last) $error("[%s] SIGNAL ERROR: tlast mismatch!", test_name);
+                    if (m_axis_tlast !== exp_last) $error("[%s] SIGNAL ERROR: tlast mismatch!", test_name);
                 end else begin
                     // SHAKE logic (Last usually 0, dependent on implementation)
-                    if (m_axis.tlast !== 0) $error("[%s] SIGNAL ERROR: SHAKE tlast should be 0!", test_name);
+                    if (m_axis_tlast !== 0) $error("[%s] SIGNAL ERROR: SHAKE tlast should be 0!", test_name);
                 end
 
                 // --- 2. DATA COLLECTION ---
-                current_word = m_axis.tdata;
-                current_keep = m_axis.tkeep;
+                current_word = m_axis_tdata;
+                current_keep = m_axis_tkeep;
 
                 for (i = 0; i < (DWIDTH/8); i++) begin
                     if (current_keep[i]) begin
@@ -413,7 +429,7 @@ module keccak_core_heavy_tb;
             end
         end
 
-        m_axis.tready = 0;
+        m_axis_tready = 0;
 
         // --- Result Reconstruction ---
         for (i = 0; i < bytes_total_expected; i++) begin

--- a/tb/keccak_core_tb.sv
+++ b/tb/keccak_core_tb.sv
@@ -33,10 +33,18 @@ module keccak_core_tb;
     // AXI4-Stream Interface Instantiation
     // ---------------------------------------------------------------------
     // Sink Interface (Input to Core)
-    axis_if #(.DWIDTH(DWIDTH)) s_axis();
+    logic [DWIDTH-1:0]      s_axis_tdata;
+    logic                   s_axis_tvalid;
+    logic                   s_axis_tlast;
+    logic [KEEP_WIDTH-1:0]  s_axis_tkeep;
+    logic                   s_axis_tready;
 
     // Source Interface (Output from Core)
-    axis_if #(.DWIDTH(DWIDTH)) m_axis();
+    logic [DWIDTH-1:0]      m_axis_tdata;
+    logic                   m_axis_tvalid;
+    logic                   m_axis_tlast;
+    logic [KEEP_WIDTH-1:0]  m_axis_tkeep;
+    logic                   m_axis_tready;
 
     // Test Vector Structure
     typedef struct {
@@ -61,10 +69,18 @@ module keccak_core_tb;
         .stop_i         (stop_i),
 
         // Connect Sink Interface (Input to DUT)
-        .s_axis         (s_axis.sink),
+        .s_axis_tdata   (s_axis_tdata),
+        .s_axis_tvalid  (s_axis_tvalid),
+        .s_axis_tlast   (s_axis_tlast),
+        .s_axis_tkeep   (s_axis_tkeep),
+        .s_axis_tready  (s_axis_tready),
 
         // Connect Source Interface (Output from DUT)
-        .m_axis         (m_axis.source)
+        .m_axis_tdata   (m_axis_tdata),
+        .m_axis_tvalid  (m_axis_tvalid),
+        .m_axis_tlast   (m_axis_tlast),
+        .m_axis_tkeep   (m_axis_tkeep),
+        .m_axis_tready  (m_axis_tready)
     );
 
     // =====================================================================
@@ -82,13 +98,13 @@ module keccak_core_tb;
         xof_len_i = 0;
 
         // Reset Sink Interface Signals (Driver side)
-        s_axis.tvalid = 0;
-        s_axis.tlast  = 0;
-        s_axis.tkeep  = 0;
-        s_axis.tdata  = 0;
+        s_axis_tvalid = 0;
+        s_axis_tlast  = 0;
+        s_axis_tkeep  = 0;
+        s_axis_tdata  = 0;
 
         // Reset Source Interface Ready (Monitor side)
-        m_axis.tready = 0;
+        m_axis_tready = 0;
 
         @(posedge clk);
         @(posedge clk);
@@ -140,23 +156,23 @@ module keccak_core_tb;
             // Wait for handshake safely using negedge sampling
             forever begin
                 @(negedge clk);
-                if (s_axis.tready) break;
+                if (s_axis_tready) break;
             end
 
             // Drive active payload at the same NegEdge
-            s_axis.tvalid <= 1;
-            s_axis.tlast  <= 1;
-            s_axis.tkeep  <= '0;
-            s_axis.tdata  <= '0;
+            s_axis_tvalid <= 1;
+            s_axis_tlast  <= 1;
+            s_axis_tkeep  <= '0;
+            s_axis_tdata  <= '0;
 
             // Wait for the RTL to sample the data exactly ONCE.
             @(posedge clk);
 
             // Transaction complete, drop valid at the following NegEdge
             @(negedge clk);
-            s_axis.tvalid <= 0;
-            s_axis.tlast  <= 0;
-            s_axis.tkeep  <= 0;
+            s_axis_tvalid <= 0;
+            s_axis_tlast  <= 0;
+            s_axis_tkeep  <= 0;
             return;
         end
 
@@ -169,18 +185,18 @@ module keccak_core_tb;
             // Wait for SLAVE to be ready BEFORE driving this beat
             forever begin
                 @(negedge clk);
-                if (s_axis.tready) break;
+                if (s_axis_tready) break;
             end
 
             // Drive beat at the same NegEdge
-            s_axis.tvalid <= 1;
-            s_axis.tlast  <= (bytes_remaining <= BYTES_PER_BEAT) ? 1'b1 : 1'b0;
-            s_axis.tkeep  <= '0;
-            s_axis.tdata  <= '0;
+            s_axis_tvalid <= 1;
+            s_axis_tlast  <= (bytes_remaining <= BYTES_PER_BEAT) ? 1'b1 : 1'b0;
+            s_axis_tkeep  <= '0;
+            s_axis_tdata  <= '0;
 
             for (k = 0; k < bytes_to_send; k++) begin
-                s_axis.tdata[k*8 +: 8] <= msg_bytes[sent_bytes + k];
-                s_axis.tkeep[k]        <= 1'b1;
+                s_axis_tdata[k*8 +: 8] <= msg_bytes[sent_bytes + k];
+                s_axis_tkeep[k]        <= 1'b1;
             end
 
             // Wait for the RTL to sample the data exactly ONCE.
@@ -191,9 +207,9 @@ module keccak_core_tb;
 
         // Drop signals safely after all beats are done
         @(negedge clk);
-        s_axis.tvalid <= 0;
-        s_axis.tlast  <= 0;
-        s_axis.tkeep  <= 0;
+        s_axis_tvalid <= 0;
+        s_axis_tlast  <= 0;
+        s_axis_tkeep  <= 0;
     endtask
 
     // =====================================================================
@@ -244,14 +260,14 @@ module keccak_core_tb;
             default:  rate_bytes = 136;
         endcase
 
-        m_axis.tready = 1;
+        m_axis_tready = 1;
         $display("[%s] Monitor: Waiting for %0d bytes...", test_name, bytes_total_expected);
 
         forever begin
             @(posedge clk);
 
             // Use interface signals for monitoring
-            if (m_axis.tvalid && m_axis.tready) begin
+            if (m_axis_tvalid && m_axis_tready) begin
 
                 // --- 1. SIGNAL VERIFICATION ---
                 // A. Determine where we are inside the Keccak "Rate Block"
@@ -289,11 +305,11 @@ module keccak_core_tb;
                 end
 
                 // C. Verify Keep
-                if (m_axis.tkeep !== exp_keep) begin
+                if (m_axis_tkeep !== exp_keep) begin
                     $error("[%s] SIGNAL ERROR: tkeep mismatch at DUT byte offset %0d",
                            test_name, bytes_squeezed_from_dut_total);
                     $display("\tExpected Keep: %b", exp_keep);
-                    $display("\tGot Keep:      %b", m_axis.tkeep);
+                    $display("\tGot Keep:      %b", m_axis_tkeep);
                 end
 
                 // D. Verify Last (Strict for SHA3 / Bounded SHAKE)
@@ -307,15 +323,15 @@ module keccak_core_tb;
                         expected_bytes_this_beat2 = bytes_remaining_in_rate_block;
 
                     if (bytes_rem <= expected_bytes_this_beat2) exp_last = 1; else exp_last = 0;
-                    if (m_axis.tlast !== exp_last) $error("[%s] SIGNAL ERROR: tlast mismatch!", test_name);
+                    if (m_axis_tlast !== exp_last) $error("[%s] SIGNAL ERROR: tlast mismatch!", test_name);
                 end else begin
                     // SHAKE logic (Last usually 0, dependent on implementation)
-                    if (m_axis.tlast !== 0) $error("[%s] SIGNAL ERROR: SHAKE tlast should be 0!", test_name);
+                    if (m_axis_tlast !== 0) $error("[%s] SIGNAL ERROR: SHAKE tlast should be 0!", test_name);
                 end
 
                 // --- 2. DATA COLLECTION ---
-                current_word = m_axis.tdata;
-                current_keep = m_axis.tkeep;
+                current_word = m_axis_tdata;
+                current_keep = m_axis_tkeep;
 
                 for (i = 0; i < (DWIDTH/8); i++) begin
                     if (current_keep[i]) begin
@@ -341,7 +357,7 @@ module keccak_core_tb;
             end
         end
 
-        m_axis.tready = 0;
+        m_axis_tready = 0;
 
         // --- Result Reconstruction ---
         for (i = 0; i < bytes_total_expected; i++) begin


### PR DESCRIPTION
This commit removes the dependency on the `axis_if` SystemVerilog interface across the Keccak core and its testbenches, replacing it with explicit AXI4-Stream signals (tdata, tvalid, tlast, tkeep, tready).

Changes:
- rtl/keccak_core.sv: Replaced `axis_if` ports with explicit wire inputs/outputs.
- tb/keccak_core_tb.sv: Updated to use flattened logic signals for AXI-Stream.
- tb/keccak_core_heavy_tb.sv: Updated to use flattened logic signals.
- rtl.f: Removed reference to `axis_if.sv`.
- Git: Removed the `lib/common_rtl` submodule as it is no longer required.

Verification:
- Successfully ran `make` and `make run_keccak_core_heavy_tb`.
- Verified 3592 test vectors passed in heavy regression.