### PR TITLE
ci/fix: optimize synthesis for sv2v/yosys flow and resolve latch issues

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,16 +12,17 @@ permissions:
 
 jobs:
   call-central-builder:
-    uses: QREM-CORE/build-tools/.github/workflows/central-builder.yml@main
+    uses: QREM-CORE/build-tools/.github/workflows/central-builder.yml@utilize_sv2v
     with:
       # Automatically targets the repository and specific commit of the PR
       rtl_repo: ${{ github.repository }}
       commit_sha: ${{ github.sha }}
 
       # Your comma-separated top modules for the Yosys synthesis matrix
-      top_modules: 'keccak_core'
+      top_modules: 'keccak_core'`
 
       enable_synth: true
       enable_lint: true
       enable_verilator: true
       enable_vsim: true
+      enable_sv2v: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
       commit_sha: ${{ github.sha }}
 
       # Your comma-separated top modules for the Yosys synthesis matrix
-      top_modules: 'keccak_core'`
+      top_modules: 'keccak_core'
 
       enable_synth: true
       enable_lint: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   call-central-builder:
-    uses: QREM-CORE/build-tools/.github/workflows/central-builder.yml@utilize_sv2v
+    uses: QREM-CORE/build-tools/.github/workflows/central-builder.yml@main
     with:
       # Automatically targets the repository and specific commit of the PR
       rtl_repo: ${{ github.repository }}

--- a/rtl/iota_step.sv
+++ b/rtl/iota_step.sv
@@ -75,14 +75,33 @@ module iota_step (
         state_array_o = state_array_i;
 
         // Build 64-bit round constant
-        round_constant = '0;
-        for (int i = 0; i < MAX_ROUNDS; i = i + 1) begin
-            if (round_index_i == i[ROUND_INDEX_SIZE-1:0]) begin
-                for (int j = 0; j < L_SIZE; j = j + 1) begin
-                    round_constant[BITMAPPING[j]] = ROUNDCONSTANTS[i][j];
-                end
-            end
-        end
+        case (round_index_i)
+            'd 0 : round_constant = 64'h0000000000000001;
+            'd 1 : round_constant = 64'h0000000000008082;
+            'd 2 : round_constant = 64'h800000000000808a;
+            'd 3 : round_constant = 64'h8000000080008000;
+            'd 4 : round_constant = 64'h000000000000808b;
+            'd 5 : round_constant = 64'h0000000080000001;
+            'd 6 : round_constant = 64'h8000000080008081;
+            'd 7 : round_constant = 64'h8000000000008009;
+            'd 8 : round_constant = 64'h000000000000008a;
+            'd 9 : round_constant = 64'h0000000000000088;
+            'd10 : round_constant = 64'h0000000080008009;
+            'd11 : round_constant = 64'h000000008000000a;
+            'd12 : round_constant = 64'h000000008000808b;
+            'd13 : round_constant = 64'h800000000000008b;
+            'd14 : round_constant = 64'h8000000000008089;
+            'd15 : round_constant = 64'h8000000000008003;
+            'd16 : round_constant = 64'h8000000000008002;
+            'd17 : round_constant = 64'h8000000000000080;
+            'd18 : round_constant = 64'h000000000000800a;
+            'd19 : round_constant = 64'h800000008000000a;
+            'd20 : round_constant = 64'h8000000080008081;
+            'd21 : round_constant = 64'h8000000000008080;
+            'd22 : round_constant = 64'h0000000080000001;
+            'd23 : round_constant = 64'h8000000080008008;
+            default: round_constant = '0;
+        endcase
 
         // Apply constant to lane (0,0) in single operation
         state_array_o[0][0] = state_array_i[0][0] ^ round_constant;

--- a/rtl/iota_step.sv
+++ b/rtl/iota_step.sv
@@ -5,9 +5,8 @@
  * - Implements the ι (Iota) step mapping, responsible for breaking symmetry
  * between the 24 rounds of the permutation.
  * - Adds a 64-bit Round Constant (RC) to Lane(0,0) via XOR.
- * - Optimized Storage: Since the RC is sparse (only 7 specific bit positions
- * can ever be '1'), this module stores only those 7 bits per round
- * instead of full 64-bit constants, reducing area usage.
+ * - Synthesis Optimized: Uses an explicit case statement for round constants
+ * to ensure clean ROM/Mux mapping in sv2v/Yosys flows.
  * - Reference: FIPS 202 Section 3.2.5
  */
 
@@ -21,53 +20,10 @@ module iota_step (
     input  wire [ROUND_INDEX_SIZE-1:0] round_index_i, // Current round index (0-23)
     output reg  [ROW_SIZE-1:0][COL_SIZE-1:0][LANE_SIZE-1:0] state_array_o
 );
-    /* ============================================================
-     * Step 1: Get Round Constant using input Round Index
-     * ============================================================
-     *
+    /*
      * A keccak permutation has 24 rounds, so we have 24 different round constants.
-     * The 64-bit round constant only has 7 possible non-zero bits at index positions:
-     * (0, 1, 3, 7, 15, 31, 63) == 2^j - 1 for j=0..6
-     * So we will only store the 7 bits that can be non-zero.
-     *
-     * The following array is as such:
-     *  - Each row corresponds to each round 0..23
-     *  - Each column corresponds to one of the 7 bit positions
+     * The 64-bit round constants are defined in FIPS 202 Table 5.
      */
-    localparam logic ROUNDCONSTANTS [MAX_ROUNDS][L_SIZE] = '{
-       //  Bit-0    Bit-1    Bit-3    Bit-7    Bit-15    Bit 31    Bit-63
-        '{ 1,       0,       0,       0,       0,        0,        0      }, // Round 0
-        '{ 0,       1,       0,       1,       1,        0,        0      }, // Round 1
-        '{ 0,       1,       1,       1,       1,        0,        1      }, // Round 2
-        '{ 0,       0,       0,       0,       1,        1,        1      }, // Round 3
-        '{ 1,       1,       1,       1,       1,        0,        0      }, // Round 4
-        '{ 1,       0,       0,       0,       0,        1,        0      }, // Round 5
-        '{ 1,       0,       0,       1,       1,        1,        1      }, // Round 6
-        '{ 1,       0,       1,       0,       1,        0,        1      }, // Round 7
-        '{ 0,       1,       1,       1,       0,        0,        0      }, // Round 8
-        '{ 0,       0,       1,       1,       0,        0,        0      }, // Round 9
-        '{ 1,       0,       1,       0,       1,        1,        0      }, // Round 10
-        '{ 0,       1,       1,       0,       0,        1,        0      }, // Round 11
-        '{ 1,       1,       1,       1,       1,        1,        0      }, // Round 12
-        '{ 1,       1,       1,       1,       0,        0,        1      }, // Round 13
-        '{ 1,       0,       1,       1,       1,        0,        1      }, // Round 14
-        '{ 1,       1,       0,       0,       1,        0,        1      }, // Round 15
-        '{ 0,       1,       0,       0,       1,        0,        1      }, // Round 16
-        '{ 0,       0,       0,       1,       0,        0,        1      }, // Round 17
-        '{ 0,       1,       1,       0,       1,        0,        0      }, // Round 18
-        '{ 0,       1,       1,       0,       0,        1,        1      }, // Round 19
-        '{ 1,       0,       0,       1,       1,        1,        1      }, // Round 20
-        '{ 0,       0,       0,       1,       1,        0,        1      }, // Round 21
-        '{ 1,       0,       0,       0,       0,        1,        0      }, // Round 22
-        '{ 0,       0,       1,       0,       1,        1,        1      }  // Round 23
-    };
-
-    // Bit position mapping: 2^j - 1 for j = 0..6
-    localparam int BITMAPPING [L_SIZE] = '{0, 1, 3, 7, 15, 31, 63};
-
-    // ============================================================
-    // Step 2: XOR corresponding round constants into lane (0,0)
-    // ============================================================
     logic [LANE_SIZE-1:0] round_constant;
 
     always_comb begin

--- a/rtl/iota_step.sv
+++ b/rtl/iota_step.sv
@@ -76,8 +76,12 @@ module iota_step (
 
         // Build 64-bit round constant
         round_constant = '0;
-        for (int j = 0; j < L_SIZE; j = j + 1) begin
-            round_constant[BITMAPPING[j]] = ROUNDCONSTANTS[round_index_i][j];
+        for (int i = 0; i < MAX_ROUNDS; i = i + 1) begin
+            if (round_index_i == i[ROUND_INDEX_SIZE-1:0]) begin
+                for (int j = 0; j < L_SIZE; j = j + 1) begin
+                    round_constant[BITMAPPING[j]] = ROUNDCONSTANTS[i][j];
+                end
+            end
         end
 
         // Apply constant to lane (0,0) in single operation

--- a/rtl/keccak_absorb_unit.sv
+++ b/rtl/keccak_absorb_unit.sv
@@ -106,28 +106,27 @@ module keccak_absorb_unit (
 
     always_comb begin
         // Default assignments to avoid latches
-        start_lane_idx = '0;
+        start_lane_idx = bytes_absorbed_i >> $clog2(BYTES_PER_LANE);
 
-        // Zero all operands
         for (int i = 0; i < 25; i++) begin
-            xor_plane[i] = '0;
-        end
+            logic [LANE_SIZE-1:0] lane_val;
+            lane_val = '0;
 
-        if (pad_en_i) begin
-            // Padding Phase (Reuses the XOR plane)
-            // Can merge if head == tail!
-            xor_plane[head_lane_idx] |= head_pad_val;
-            xor_plane[tail_lane_idx] |= tail_pad_val;
-        end else begin
-            // Normal Absorb Phase
-            start_lane_idx = bytes_absorbed_i >> $clog2(BYTES_PER_LANE);
-
-            for (int i = 0; i < INPUT_LANE_NUM; i = i + 1) begin
-                automatic logic [$clog2(ROW_SIZE*COL_SIZE)-1:0] current_lane_idx = start_lane_idx + i;
-                if (current_lane_idx < rate_lane_limit && current_lane_idx < MAX_POSSIBLE_LANES) begin
-                    xor_plane[current_lane_idx] = split_lanes[i];
+            if (pad_en_i) begin
+                // Padding Phase: Determine if this lane receives head or tail padding
+                if (i == head_lane_idx) lane_val |= head_pad_val;
+                if (i == tail_lane_idx) lane_val |= tail_pad_val;
+            end else begin
+                // Normal Absorb Phase: Check if this lane corresponds to an input lane
+                for (int j = 0; j < INPUT_LANE_NUM; j++) begin
+                    if (i == (start_lane_idx + j)) begin
+                        if (i < rate_lane_limit && i < MAX_POSSIBLE_LANES) begin
+                            lane_val = split_lanes[j];
+                        end
+                    end
                 end
             end
+            xor_plane[i] = lane_val;
         end
 
         // Single monolithic 1600-bit XOR execution

--- a/rtl/keccak_absorb_unit.sv
+++ b/rtl/keccak_absorb_unit.sv
@@ -86,6 +86,7 @@ module keccak_absorb_unit (
     assign rate_lane_limit = rate_i[RATE_WIDTH-1:$clog2(LANE_SIZE)]; // rate_i / 64
 
     logic [$clog2(ROW_SIZE*COL_SIZE)-1:0] start_lane_idx;
+    assign start_lane_idx = bytes_absorbed_i >> $clog2(BYTES_PER_LANE);
 
     // Padder Coordinates
     logic [$clog2(ROW_SIZE*COL_SIZE)-1:0] head_lane_idx;
@@ -104,38 +105,41 @@ module keccak_absorb_unit (
     // Single 1600-bit XOR operand plane multiplexed across Absorb and Padding
     logic [63:0] xor_plane [25];
 
+    // Construct the XOR operand plane
     always_comb begin
-        // Default assignments to avoid latches
-        start_lane_idx = bytes_absorbed_i >> $clog2(BYTES_PER_LANE);
+        // Default to zero
+        for (int i = 0; i < 25; i++) xor_plane[i] = '0;
 
-        for (int i = 0; i < 25; i++) begin
-            logic [LANE_SIZE-1:0] lane_val;
-            lane_val = '0;
-
-            if (pad_en_i) begin
-                // Padding Phase: Determine if this lane receives head or tail padding
-                if (i == head_lane_idx) lane_val |= head_pad_val;
-                if (i == tail_lane_idx) lane_val |= tail_pad_val;
-            end else begin
-                // Normal Absorb Phase: Check if this lane corresponds to an input lane
-                for (int j = 0; j < INPUT_LANE_NUM; j++) begin
-                    if (i == (start_lane_idx + j)) begin
-                        if (i < rate_lane_limit && i < MAX_POSSIBLE_LANES) begin
-                            lane_val = split_lanes[j];
-                        end
+        if (pad_en_i) begin
+            // Padding Phase
+            // Use explicit checks for head/tail to avoid variable indexing in a complex way
+            for (int i = 0; i < 25; i++) begin
+                if (i == head_lane_idx) xor_plane[i] |= head_pad_val;
+                if (i == tail_lane_idx) xor_plane[i] |= tail_pad_val;
+            end
+        end else begin
+            // Normal Absorb Phase
+            // INPUT_LANE_NUM is 1 (DWIDTH=64, LANE_SIZE=64)
+            // Match the single input lane to its target offset
+            for (int i = 0; i < 25; i++) begin
+                if (i == start_lane_idx) begin
+                    if (i < rate_lane_limit && i < MAX_POSSIBLE_LANES) begin
+                        xor_plane[i] = split_lanes[0];
                     end
                 end
             end
-            xor_plane[i] = lane_val;
-        end
-
-        // Single monolithic 1600-bit XOR execution
-        for (int i = 0; i < 25; i++) begin
-            automatic int x = i % COL_SIZE;
-            automatic int y = i / COL_SIZE;
-            state_array_o[x][y] = state_array_i[x][y] ^ xor_plane[i];
         end
     end
+
+    // Single monolithic 1600-bit XOR execution via generate
+    genvar x_idx, y_idx;
+    generate
+        for (y_idx = 0; y_idx < 5; y_idx = y_idx + 1) begin : g_xor_y
+            for (x_idx = 0; x_idx < 5; x_idx = x_idx + 1) begin : g_xor_x
+                assign state_array_o[x_idx][y_idx] = state_array_i[x_idx][y_idx] ^ xor_plane[x_idx + 5*y_idx];
+            end
+        end
+    endgenerate
 
 endmodule
 

--- a/rtl/keccak_core.sv
+++ b/rtl/keccak_core.sv
@@ -408,6 +408,7 @@ module keccak_core (
     // ----------------------------------------------------------
     always_comb begin
         // Defaults:
+        state_array_in_sel = KSU_SEL;
 
         // ----- Outputs -----
         // AXI4-Stream Signals - Sink

--- a/rtl/keccak_output_unit.sv
+++ b/rtl/keccak_output_unit.sv
@@ -47,19 +47,23 @@ module keccak_output_unit (
     logic [1599:0] state_linear;
     logic [NUM_OUTPUT_WORDS-1:0][DWIDTH-1:0] state_words;
 
-    always_comb begin
-        // 1. Flatten 3D to 1D
-        for (int y = 0; y < 5; y++) begin
-            for (int x = 0; x < 5; x++) begin
-                // Calculate linear lane index: i = 5*y + x
-                state_linear[(x + 5*y) * 64 +: 64] = state_array_i[x][y];
+    // 1. Flatten 3D to 1D via Generate
+    genvar x_gen, y_gen;
+    generate
+        for (y_gen = 0; y_gen < 5; y_gen = y_gen + 1) begin : g_flat_y
+            for (x_gen = 0; x_gen < 5; x_gen = x_gen + 1) begin : g_flat_x
+                assign state_linear[(x_gen + 5*y_gen) * 64 +: 64] = state_array_i[x_gen][y_gen];
             end
         end
-        // 2. Cast 1D array into Word-Aligned Boundaries
-        for (int i = 0; i < NUM_OUTPUT_WORDS; i++) begin
-            state_words[i] = state_linear[i * DWIDTH +: DWIDTH];
+    endgenerate
+
+    // 2. Cast 1D array into Word-Aligned Boundaries via Generate
+    genvar i_gen;
+    generate
+        for (i_gen = 0; i_gen < NUM_OUTPUT_WORDS; i_gen = i_gen + 1) begin : g_cast
+            assign state_words[i_gen] = state_linear[i_gen * DWIDTH +: DWIDTH];
         end
-    end
+    endgenerate
 
     // ==========================================================
     // 3. EXTRACT OUTPUT WORD (High-Fmax Multiplexer)

--- a/rtl/keccak_output_unit.sv
+++ b/rtl/keccak_output_unit.sv
@@ -69,12 +69,34 @@ module keccak_output_unit (
     assign current_word_idx = bytes_squeezed_i >> $clog2(DWIDTH / 8);
 
     always_comb begin
-        data_o = '0;
-        for (int i = 0; i < NUM_OUTPUT_WORDS; i++) begin
-            if (current_word_idx == i[$clog2(NUM_OUTPUT_WORDS)-1:0]) begin
-                data_o = state_words[i];
-            end
-        end
+        case (current_word_idx)
+            'd 0 : data_o = state_words[ 0];
+            'd 1 : data_o = state_words[ 1];
+            'd 2 : data_o = state_words[ 2];
+            'd 3 : data_o = state_words[ 3];
+            'd 4 : data_o = state_words[ 4];
+            'd 5 : data_o = state_words[ 5];
+            'd 6 : data_o = state_words[ 6];
+            'd 7 : data_o = state_words[ 7];
+            'd 8 : data_o = state_words[ 8];
+            'd 9 : data_o = state_words[ 9];
+            'd10 : data_o = state_words[10];
+            'd11 : data_o = state_words[11];
+            'd12 : data_o = state_words[12];
+            'd13 : data_o = state_words[13];
+            'd14 : data_o = state_words[14];
+            'd15 : data_o = state_words[15];
+            'd16 : data_o = state_words[16];
+            'd17 : data_o = state_words[17];
+            'd18 : data_o = state_words[18];
+            'd19 : data_o = state_words[19];
+            'd20 : data_o = state_words[20];
+            'd21 : data_o = state_words[21];
+            'd22 : data_o = state_words[22];
+            'd23 : data_o = state_words[23];
+            'd24 : data_o = state_words[24];
+            default: data_o = '0;
+        endcase
     end
 
     // ==========================================================

--- a/rtl/keccak_output_unit.sv
+++ b/rtl/keccak_output_unit.sv
@@ -69,7 +69,12 @@ module keccak_output_unit (
     assign current_word_idx = bytes_squeezed_i >> $clog2(DWIDTH / 8);
 
     always_comb begin
-        data_o = state_words[current_word_idx];
+        data_o = '0;
+        for (int i = 0; i < NUM_OUTPUT_WORDS; i++) begin
+            if (current_word_idx == i[$clog2(NUM_OUTPUT_WORDS)-1:0]) begin
+                data_o = state_words[i];
+            end
+        end
     end
 
     // ==========================================================


### PR DESCRIPTION
# PR Description

## Problem
- **Synthesis Hang**: CI builds were hanging for 6+ hours (timing out) during Yosys `PROC_DLATCH` and `PROC_MUX` passes.
- **Root Cause**: `sv2v` flattening combined with bit-level loops in `always_comb` blocks (specifically those with variable-indexed 3D arrays) generated over 40,000 individual processes, overwhelming the synthesis tool.
- **Functional Bugs**: 
    - Latch inferred for `state_array_in_sel` in `keccak_core.sv` due to missing default assignment.
    - `keccak_absorb_unit.sv` simulation failing due to uninitialized `start_lane_idx`.

## Solution
- **ROM/Mux Optimization**: Refactored `iota_step.sv` and `keccak_output_unit.sv` to use explicit `case` statements for round constants and word selection. 
- **Flattening Refactor**: Replaced `always_comb` loops in `keccak_output_unit.sv` with `generate` blocks for state array flattening and word casting. This prevents `sv2v` from unrolling array assignments into thousands of bit-level processes.
- **Process Decomposition**: Refactored `keccak_absorb_unit.sv` to use `generate` blocks for the 1600-bit state XOR, moving logic out of a monolithic `always_comb` process into 25 independent assignments.
- **Cleanup**: Removed unused sparse-storage constants (`ROUNDCONSTANTS`, `BITMAPPING`) and outdated comments in `iota_step.sv`.
- **Latch Fix**: Added default assignment for `state_array_in_sel` in `keccak_core.sv`.
- **Simulation Fix**: Assigned `start_lane_idx` in `keccak_absorb_unit.sv`.

## Result
- **Synthesis Speed**: CI build time reduced from >6 hours to a few minutes.
- **Code Quality**: Eliminated latch warnings and fixed uninitialized signal bugs.
- **Verification**: All unit tests (`iota_step_tb`, `keccak_output_unit_tb`, `keccak_absorb_unit_tb`) and the full `keccak_core_tb` pass locally with both Verilator and ModelSim.